### PR TITLE
Enable Network-Based Spam checking

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -137,6 +137,7 @@ class postfix::server (
   $spampd_relayport           = '10027',
   $spampd_children            = '20',
   $spampd_maxsize             = '512',
+  $spampd_local_only          = '0',
   # Other filters
   $postgrey                = false,
   $postgrey_policy_service = undef,

--- a/templates/default-spampd.erb
+++ b/templates/default-spampd.erb
@@ -39,7 +39,7 @@ AUTOWHITELIST=0
 # Wether or not to do only local checks 
 # if this is turned on, no network based checks
 # (like DNS-Blacklists) are done. (0/1)
-LOCALONLY=1
+LOCALONLY=<%= @spampd_local_only %>
 
 # Wether to prefer INET (network,1) for syslog logging
 # instead of UNIX (unix domain socket,0) (0/1)


### PR DESCRIPTION
Why would you ever want this off?  

This flag renders DCC, DNSBL etc absolutely useless and makes the mail server need to stand-alone spam filtering, even if you enable plugins that support it.