### PR TITLE
Add support for smtpd rate limit params

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -86,8 +86,8 @@ class postfix::server (
   $smtp_generic_maps = false,
   $relocated_maps = false,
   $extra_main_parameters = {},
-  $smtpd_client_message_rate_limit = 0,
-  $smtpd_client_recipient_rate_limit = 0,
+  $smtpd_client_message_rate_limit = undef,
+  $smtpd_client_recipient_rate_limit = undef,
   # master.cf
   $smtp_content_filter = [],
   $smtps_content_filter = [],

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -86,8 +86,8 @@ class postfix::server (
   $smtp_generic_maps = false,
   $relocated_maps = false,
   $extra_main_parameters = {},
-  $smtpd_client_message_rate_limit = 0
-  $smtpd_client_recipient_rate_limit = 0
+  $smtpd_client_message_rate_limit = 0,
+  $smtpd_client_recipient_rate_limit = 0,
   # master.cf
   $smtp_content_filter = [],
   $smtps_content_filter = [],

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -86,6 +86,8 @@ class postfix::server (
   $smtp_generic_maps = false,
   $relocated_maps = false,
   $extra_main_parameters = {},
+  $smtpd_client_message_rate_limit = 0
+  $smtpd_client_recipient_rate_limit = 0
   # master.cf
   $smtp_content_filter = [],
   $smtps_content_filter = [],

--- a/templates/main.cf-el5.erb
+++ b/templates/main.cf-el5.erb
@@ -928,3 +928,13 @@ smtp_generic_maps = <%= @smtp_generic_maps %>
 <% end -%>
 
 <% end -%>
+# SMTP rate limits
+
+<% if @smtpd_client_message_rate_limit -%>
+smtpd_client_message_rate_limit = <%= @smtpd_client_message_rate_limit %>
+
+<% end -%>
+<% if @smtpd_client_recipient_rate_limit -%>
+smtpd_client_recipient_rate_limit = <%= @smtpd_client_recipient_rate_limit %>
+
+<% end -%>

--- a/templates/main.cf.erb
+++ b/templates/main.cf.erb
@@ -974,3 +974,14 @@ postscreen_dnsbl_action = <%= @postscreen_dnsbl_action %>
 <% end -%>
 
 <% end -%>
+
+# SMTP rate limits
+
+<% if @smtpd_client_message_rate_limit -%>
+smtpd_client_message_rate_limit = <%= @smtpd_client_message_rate_limit %>
+
+<% end -%>
+<% if @smtpd_client_recipient_rate_limit -%>
+smtpd_client_recipient_rate_limit = <%= @smtpd_client_recipient_rate_limit %>
+
+<% end -%>


### PR DESCRIPTION
Add two new parameters;`smtpd_client_message_rate_limit` and `smtpd_client_recipient_rate_limit` to main.cf.

Default for both parameters is set to `0`, which mirrors the default configuration outlined in the [docs](http://www.postfix.org/postconf.5.html).